### PR TITLE
Issue #17 type system

### DIFF
--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/EntryBuilder.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/EntryBuilder.java
@@ -29,7 +29,6 @@ import com.redhat.lightblue.metadata.ArrayElement;
 import com.redhat.lightblue.metadata.ArrayField;
 import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.ObjectField;
-import com.redhat.lightblue.metadata.ReferenceField;
 import com.redhat.lightblue.metadata.SimpleField;
 import com.redhat.lightblue.metadata.Type;
 import com.redhat.lightblue.metadata.types.BinaryType;
@@ -101,11 +100,6 @@ public class EntryBuilder extends TranslatorFromJson<Entry>{
     @Override
     protected void translate(ObjectField field, Path path, JsonNode node, Entry target) {
         throw new UnsupportedOperationException("ObjectField type is not currently supported.");
-    }
-
-    @Override
-    protected void translate(ReferenceField field, Path path, JsonNode node, Entry target) {
-        throw new UnsupportedOperationException("ReferenceField type is not currently supported.");
     }
 
     @Override

--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/EntryBuilder.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/EntryBuilder.java
@@ -1,0 +1,138 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.crud.ldap;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.common.ldap.LdapConstant;
+import com.redhat.lightblue.common.ldap.LightblueUtil;
+import com.redhat.lightblue.metadata.ArrayElement;
+import com.redhat.lightblue.metadata.ArrayField;
+import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.ObjectField;
+import com.redhat.lightblue.metadata.ReferenceField;
+import com.redhat.lightblue.metadata.SimpleField;
+import com.redhat.lightblue.metadata.Type;
+import com.redhat.lightblue.metadata.types.BinaryType;
+import com.redhat.lightblue.metadata.types.DateType;
+import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonNodeCursor;
+import com.redhat.lightblue.util.Path;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.util.StaticUtils;
+
+/**
+ * Builds populated instances of {@link Entry} for LDAP interaction.
+ *
+ * @author dcrissman
+ */
+public class EntryBuilder extends TranslatorFromJson<Entry>{
+
+    public EntryBuilder(EntityMetadata md){
+        super(md);
+    }
+
+    public Entry build(String dn, JsonDoc document){
+        Entry entry = new Entry(dn);
+        translate(document, entry);
+        return entry;
+    }
+
+    @Override
+    protected Object fromJson(Type type, JsonNode node){
+        if(type instanceof DateType){
+            return StaticUtils.encodeGeneralizedTime((Date)type.fromJson(node));
+        }
+        else if(type instanceof BinaryType){
+            return type.fromJson(node);
+        }
+        else{
+            return super.fromJson(type, node).toString();
+        }
+    }
+
+    @Override
+    protected void translate(SimpleField field, Path path, JsonNode node, Entry target) {
+        String fieldName = field.getName();
+
+        if(LdapConstant.FIELD_DN.equalsIgnoreCase(fieldName)){
+            throw new IllegalArgumentException(
+                    "'dn' should not be included as it's value will be derived from the metadata.basedn and" +
+                    " the metadata.uniqueattr. Including the 'dn' as an insert attribute is confusing.");
+        }
+        else if(LightblueUtil.isFieldObjectType(fieldName)
+                || LightblueUtil.isFieldAnArrayCount(fieldName, getEntityMetadata().getFields())){
+            /*
+             * Indicates the field is auto-generated for lightblue purposes. These fields
+             * should not be inserted into LDAP.
+             */
+            return;
+        }
+
+        Type type = field.getType();
+        Object o = fromJson(type, node);
+        if(type instanceof BinaryType) {
+            target.addAttribute(fieldName, (byte[])o);
+        }
+        else{
+            target.addAttribute(fieldName, o.toString());
+        }
+    }
+
+    @Override
+    protected void translate(ObjectField field, Path path, JsonNode node, Entry target) {
+        throw new UnsupportedOperationException("ObjectField type is not currently supported.");
+    }
+
+    @Override
+    protected void translate(ReferenceField field, Path path, JsonNode node, Entry target) {
+        throw new UnsupportedOperationException("ReferenceField type is not currently supported.");
+    }
+
+    @Override
+    protected void translateSimpleArray(ArrayField field, Path path, List<Object> items, Entry target) {
+        ArrayElement arrayElement = field.getElement();
+        Type arrayElementType = arrayElement.getType();
+        String fieldName = field.getName();
+
+        if(arrayElementType instanceof BinaryType){
+            List<byte[]> bytes = new ArrayList<byte[]>();
+            for(Object item : items){
+                bytes.add((byte[])item);
+            }
+            target.addAttribute(fieldName, bytes.toArray(new byte[0][]));
+        }
+        else{
+            List<String> values = new ArrayList<String>();
+            for(Object item : items){
+                values.add(item.toString());
+            }
+            target.addAttribute(fieldName, values);
+        }
+    }
+
+    @Override
+    protected void translateObjectArray(ArrayField field, JsonNodeCursor cursor, Entry target) {
+        throw new UnsupportedOperationException("Object ArrayField type is not currently supported.");
+    }
+
+}

--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/TranslatorFromJson.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/TranslatorFromJson.java
@@ -130,9 +130,12 @@ public abstract class TranslatorFromJson<T> {
         cursor.parent();
     }
 
+    protected void translate(ReferenceField field, Path path, JsonNode node, T target){
+        //Do nothing by default!
+    }
+
     protected abstract void translate(SimpleField field, Path path, JsonNode node, T target);
     protected abstract void translate(ObjectField field, Path path, JsonNode node, T target);
-    protected abstract void translate(ReferenceField field, Path path, JsonNode node, T target);
     protected abstract void translateSimpleArray(ArrayField field, Path path, List<Object> items, T target);
     protected abstract void translateObjectArray(ArrayField field, JsonNodeCursor cursor, T target);
 

--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/TranslatorFromJson.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/TranslatorFromJson.java
@@ -85,7 +85,7 @@ public abstract class TranslatorFromJson<T> {
         FieldTreeNode fieldNode = md.resolve(path);
 
         if (fieldNode == null) {
-            throw new IllegalArgumentException(path.toString());
+            throw new NullPointerException("No Metadata field found for: " + path.toString());
         }
 
         if (fieldNode instanceof SimpleField) {

--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/TranslatorFromJson.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/TranslatorFromJson.java
@@ -1,0 +1,139 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.crud.ldap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.redhat.lightblue.metadata.ArrayElement;
+import com.redhat.lightblue.metadata.ArrayField;
+import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.FieldTreeNode;
+import com.redhat.lightblue.metadata.ObjectArrayElement;
+import com.redhat.lightblue.metadata.ObjectField;
+import com.redhat.lightblue.metadata.ReferenceField;
+import com.redhat.lightblue.metadata.SimpleArrayElement;
+import com.redhat.lightblue.metadata.SimpleField;
+import com.redhat.lightblue.metadata.Type;
+import com.redhat.lightblue.util.JsonDoc;
+import com.redhat.lightblue.util.JsonNodeCursor;
+import com.redhat.lightblue.util.Path;
+
+/**
+ * Defines a class that translates lightblue json nodes into
+ * something that a specific datasource can understand.
+ *
+ * @author dcrissman
+ *
+ * @param <T> - A entity that the specific datastore knows how
+ * to interact with.
+ */
+public abstract class TranslatorFromJson<T> {
+
+    private final EntityMetadata md;
+
+    public TranslatorFromJson(EntityMetadata md){
+        this.md = md;
+    }
+
+    protected EntityMetadata getEntityMetadata(){
+        return md;
+    }
+
+    protected Object fromJson(Type type, JsonNode node){
+        if (node == null || node instanceof NullNode) {
+            return null;
+        }
+        else {
+            return type.fromJson(node);
+        }
+    }
+
+    protected void translate(JsonDoc document, T target){
+        JsonNodeCursor cursor = document.cursor();
+        if (!cursor.firstChild()) {
+            //TODO throw exception?
+            return;
+        }
+
+        do {
+            translate(cursor, target);
+        } while (cursor.nextSibling());
+    }
+
+    private void translate(JsonNodeCursor cursor, T target){
+        Path path = cursor.getCurrentPath();
+        JsonNode node = cursor.getCurrentNode();
+        FieldTreeNode fieldNode = md.resolve(path);
+
+        if (fieldNode == null) {
+            throw new IllegalArgumentException(path.toString());
+        }
+
+        if (fieldNode instanceof SimpleField) {
+            translate((SimpleField) fieldNode, path, node, target);
+        }
+        else if (fieldNode instanceof ObjectField) {
+            translate((ObjectField) fieldNode, path, node, target);
+        }
+        else if (fieldNode instanceof ArrayField) {
+            translate((ArrayField) fieldNode, cursor, path, target);
+        }
+        else if (fieldNode instanceof ReferenceField) {
+            translate((ReferenceField) fieldNode, path, node, target);
+        }
+        else{
+            throw new UnsupportedOperationException("Field type is not supported: " + fieldNode.getClass().getName());
+        }
+    }
+
+    private void translate(ArrayField field, JsonNodeCursor cursor, Path path, T target){
+        if(!cursor.firstChild()){
+            //TODO: throw exception?
+            return;
+        }
+
+        ArrayElement arrayElement = field.getElement();
+
+        if (arrayElement instanceof SimpleArrayElement) {
+            List<Object> items = new ArrayList<Object>();
+            do {
+                items.add(fromJson(arrayElement.getType(), cursor.getCurrentNode()));
+            } while (cursor.nextSibling());
+            translateSimpleArray(field, path, items, target);
+        }
+        else if(arrayElement instanceof ObjectArrayElement){
+            translateObjectArray(field, cursor, target);
+        }
+        else{
+            throw new UnsupportedOperationException("ArrayElement type is not supported: " + arrayElement.getClass().getName());
+        }
+
+        cursor.parent();
+    }
+
+    protected abstract void translate(SimpleField field, Path path, JsonNode node, T target);
+    protected abstract void translate(ObjectField field, Path path, JsonNode node, T target);
+    protected abstract void translate(ReferenceField field, Path path, JsonNode node, T target);
+    protected abstract void translateSimpleArray(ArrayField field, Path path, List<Object> items, T target);
+    protected abstract void translateObjectArray(ArrayField field, JsonNodeCursor cursor, T target);
+
+}

--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslator.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslator.java
@@ -142,6 +142,10 @@ public class ResultTranslator {
             value = attr.getValue();
         }
 
+        if(value == null){
+            throw new NullPointerException("Unable to convert LDAP attribute to json resulting in a null value: " + attr);
+        }
+
         return field.getType().toJson(factory, value);
     }
 

--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslator.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslator.java
@@ -18,9 +18,6 @@
  */
 package com.redhat.lightblue.crud.ldap.translator;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -44,7 +41,6 @@ import com.redhat.lightblue.metadata.types.IntegerType;
 import com.redhat.lightblue.metadata.types.StringType;
 import com.redhat.lightblue.util.JsonDoc;
 import com.unboundid.ldap.sdk.Attribute;
-import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 
 /**
@@ -58,14 +54,6 @@ public class ResultTranslator {
 
     public ResultTranslator(JsonNodeFactory factory){
         this.factory = factory;
-    }
-
-    public List<DocCtx> translate(SearchResult result, EntityMetadata md){
-        List<DocCtx> docs = new ArrayList<DocCtx>();
-        for(SearchResultEntry entry : result.getSearchEntries()){
-            docs.add(translate(entry, md));
-        }
-        return docs;
     }
 
     public DocCtx translate(SearchResultEntry entry, EntityMetadata md){
@@ -143,7 +131,7 @@ public class ResultTranslator {
         }
 
         if(value == null){
-            throw new NullPointerException("Unable to convert LDAP attribute to json resulting in a null value: " + attr);
+            throw new NullPointerException("Unable to convert LDAP attribute to json resulting in a null value: " + attr.getName());
         }
 
         return field.getType().toJson(factory, value);

--- a/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/EntryBuilderTest.java
+++ b/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/EntryBuilderTest.java
@@ -1,0 +1,105 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.crud.ldap;
+
+import static com.redhat.lightblue.util.JsonUtils.json;
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadResource;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.redhat.lightblue.common.ldap.LdapConstant;
+import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.types.DateType;
+import com.redhat.lightblue.test.MetadataUtil;
+import com.redhat.lightblue.util.JsonDoc;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.util.StaticUtils;
+
+@RunWith(value = Parameterized.class)
+public class EntryBuilderTest {
+
+    private final static Date now = new Date();
+
+    @Parameters(name= "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {"{\"type\": \"string\"}", quote("teststring"), "teststring"},
+                {"{\"type\": \"integer\"}", "4", null},
+                {"{\"type\": \"boolean\"}", "true", null},
+                {"{\"type\": \"date\"}", quote(DateType.getDateFormat().format(now)), StaticUtils.encodeGeneralizedTime(now)},
+                {"{\"type\": \"binary\"}", quote(DatatypeConverter.printBase64Binary("test binary data".getBytes())), "test binary data"},
+                {"{\"type\": \"array\", \"items\": {\"type\": \"string\"}}", "[\"hello\",\"world\"]", new String[]{"hello", "world"}},
+                {"{\"type\": \"array\", \"items\": {\"type\": \"binary\"}}",
+                    "[" + quote(DatatypeConverter.printBase64Binary("hello".getBytes())) + ","
+                            + quote(DatatypeConverter.printBase64Binary("world".getBytes())) + "]",
+                            new String[]{"hello", "world"}
+                },
+        });
+    }
+
+    private static String quote(String text){
+        return '"' + text + '"';
+    }
+
+    private final String fieldName = "testfield";
+    private final String metadataType;
+    private final String crudValue;
+    private final Object expectedValue;
+
+    public EntryBuilderTest(String metadataType, String crudValue, Object expectedValue){
+        this.metadataType = metadataType;
+        this.crudValue = crudValue;
+        this.expectedValue = (expectedValue == null) ? crudValue : expectedValue;
+    }
+
+    @Test
+    public void test() throws Exception{
+        String metadata = loadResource("./metadata/entryBuilderTest-metadata-template.json")
+                .replaceFirst("#fieldname", fieldName)
+                .replaceFirst("#type", metadataType);
+        String crud = loadResource("./crud/insert/entryBuilderTest-insert-template.json")
+                .replaceFirst("#fieldname", fieldName)
+                .replaceFirst("#value", crudValue);
+
+        EntityMetadata md = MetadataUtil.createEntityMetadata(LdapConstant.BACKEND, json(metadata), null, null);
+        EntryBuilder builder = new EntryBuilder(md);
+
+        Entry entry = builder.build("uid=someuid,dc=example,dc=com",
+                new JsonDoc(json(crud).get("data")));
+
+        if(expectedValue.getClass().isArray()){
+            assertArrayEquals((String[]) expectedValue, entry.getAttributeValues("testfield"));
+        }
+        else{
+            assertEquals(expectedValue, entry.getAttributeValue("testfield"));
+        }
+    }
+
+}

--- a/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/EntryBuilderTest.java
+++ b/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/EntryBuilderTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -35,9 +36,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 import com.redhat.lightblue.common.ldap.LdapConstant;
 import com.redhat.lightblue.common.ldap.LightblueUtil;
+import com.redhat.lightblue.crud.ldap.EntryBuilderTest.ParameterizedTests;
+import com.redhat.lightblue.crud.ldap.EntryBuilderTest.SpecializedTests;
 import com.redhat.lightblue.metadata.EntityMetadata;
 import com.redhat.lightblue.metadata.types.DateType;
 import com.redhat.lightblue.test.MetadataUtil;
@@ -45,6 +50,8 @@ import com.redhat.lightblue.util.JsonDoc;
 import com.unboundid.ldap.sdk.Entry;
 import com.unboundid.util.StaticUtils;
 
+@RunWith(Suite.class)
+@SuiteClasses({ParameterizedTests.class, SpecializedTests.class})
 public class EntryBuilderTest {
 
     protected static Entry buildEntry(String fieldName, String metadataType, String crudValue) throws Exception{
@@ -120,6 +127,10 @@ public class EntryBuilderTest {
                     {"{\"type\": \"string\"}", quote("teststring"), "teststring"},
                     {"{\"type\": \"integer\"}", "4", null},
                     {"{\"type\": \"boolean\"}", "true", null},
+                    {"{\"type\": \"bigdecimal\"}", String.valueOf(Double.MAX_VALUE), "1.7976931348623157E+308"},
+                    {"{\"type\": \"biginteger\"}", BigInteger.ZERO.toString(), BigInteger.ZERO.toString()},
+                    {"{\"type\": \"double\"}", String.valueOf(Double.MAX_VALUE), String.valueOf(Double.MAX_VALUE)},
+                    {"{\"type\": \"uid\"}", quote("fake-uid"), "fake-uid"},
                     {"{\"type\": \"date\"}", quote(DateType.getDateFormat().format(now)), StaticUtils.encodeGeneralizedTime(now)},
                     {"{\"type\": \"binary\"}", quote(DatatypeConverter.printBase64Binary("test binary data".getBytes())), "test binary data"},
                     {"{\"type\": \"array\", \"items\": {\"type\": \"string\"}}", "[\"hello\",\"world\"]", new String[]{"hello", "world"}},

--- a/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslatorTest.java
+++ b/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslatorTest.java
@@ -22,10 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.UUID;
 
 import org.json.JSONException;
@@ -56,9 +54,7 @@ import com.redhat.lightblue.metadata.types.UIDType;
 import com.redhat.lightblue.util.JsonDoc;
 import com.redhat.lightblue.util.Path;
 import com.unboundid.ldap.sdk.Attribute;
-import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchResultEntry;
-import com.unboundid.ldap.sdk.SearchResultReference;
 
 public class ResultTranslatorTest {
 
@@ -66,133 +62,121 @@ public class ResultTranslatorTest {
 
     @Test
     public void testTranslate_SimpleField_String() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("uid", "john.doe")
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("uid", "john.doe")
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("uid", StringType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"uid\":\"john.doe\",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_SimpleField_Integer() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", "4")
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", "4")
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", IntegerType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":4,\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_SimpleField_Boolean() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", "true")
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", "true")
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", BooleanType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":true,\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_SimpleField_BigDecimalType() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", String.valueOf(Double.MAX_VALUE))
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", String.valueOf(Double.MAX_VALUE))
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", BigDecimalType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":" + String.valueOf(Double.MAX_VALUE) + ",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_SimpleField_BigIntegerType() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", BigInteger.ZERO.toString())
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", BigInteger.ZERO.toString())
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", BigIntegerType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":" + BigInteger.ZERO + ",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_SimpleField_DoubleType() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", String.valueOf(Double.MAX_VALUE))
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", String.valueOf(Double.MAX_VALUE))
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", DoubleType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":" + String.valueOf(Double.MAX_VALUE) + ",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
@@ -200,32 +184,29 @@ public class ResultTranslatorTest {
     public void testTranslate_SimpleField_UIDType() throws JSONException{
         String uuid = UUID.randomUUID().toString();
 
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", uuid)
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", uuid)
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", UIDType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":" + uuid + ",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test(expected = NullPointerException.class)
     public void testTranslate_SimpleField_NullValue() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("uid")
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("uid")
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("uid", StringType.TYPE)
@@ -238,90 +219,82 @@ public class ResultTranslatorTest {
     public void testTranslate_SimpleField_BinaryType() throws Exception{
         byte[] bite = new byte[]{1, 2, 3, 'a', 'b', 'c'};
 
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", bite)
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", bite)
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", BinaryType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
-        JsonDoc document = documents.get(0).getOutputDocument();
+        assertNotNull(document);
+        JsonDoc jsonDocument = document.getOutputDocument();
 
-        JsonNode keyNode = document.get(new Path("key"));
+        JsonNode keyNode = jsonDocument.get(new Path("key"));
         assertEquals(bite, keyNode.binaryValue());
 
         JSONAssert.assertEquals(
                 "{\"key\":\"" + keyNode.asText() + "\",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                document.toString(),
+                jsonDocument.toString(),
                 true);
     }
 
     @Test
     public void testTranslate_SimpleField_Date() throws JSONException{
         //Note in and out data are formatted differently
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("key", "20150109201731.570Z")
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("key", "20150109201731.570Z")
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("key", DateType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"key\":\"20150109T20:17:31.570+0000\",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_ObjectType() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{}));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{});
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("objectType", StringType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"objectType\":\"fakeMetadata\",\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test
     public void testTranslate_AttributeDoesNotExist() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{}));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{});
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new SimpleField("absentAttribute", StringType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"absentAttribute\":null,\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
@@ -331,23 +304,21 @@ public class ResultTranslatorTest {
      */
     @Test
     public void testTranslate_SimpleArrayElement_CountNotAskedFor() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("objectClass", Arrays.asList("top", "person", "organizationalPerson", "inetOrgPerson"))
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("objectClass", Arrays.asList("top", "person", "organizationalPerson", "inetOrgPerson"))
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new ArrayField("objectClass", new SimpleArrayElement(StringType.TYPE))
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"objectClass\":[\"top\",\"person\",\"organizationalPerson\",\"inetOrgPerson\"],\"objectClass#\":4,\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
@@ -358,33 +329,30 @@ public class ResultTranslatorTest {
      */
     @Test
     public void testTranslate_SimpleArrayElement_CountAskedFor() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("objectClass", Arrays.asList("top", "person", "organizationalPerson", "inetOrgPerson"))
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("objectClass", Arrays.asList("top", "person", "organizationalPerson", "inetOrgPerson"))
+        });
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new ArrayField("objectClass", new SimpleArrayElement(StringType.TYPE)),
                 new SimpleField("objectClass#", IntegerType.TYPE)
                 );
 
-        List<DocCtx> documents = new ResultTranslator(factory).translate(result, md);
+        DocCtx document = new ResultTranslator(factory).translate(result, md);
 
-        assertNotNull(documents);
-        assertEquals(1, documents.size());
+        assertNotNull(document);
 
         JSONAssert.assertEquals(
                 "{\"objectClass\":[\"top\",\"person\",\"organizationalPerson\",\"inetOrgPerson\"],\"objectClass#\":4,\"dn\":\"uid=john.doe,dc=example,dc=com\"}",
-                documents.get(0).getOutputDocument().toString(),
+                document.getOutputDocument().toString(),
                 true);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testTranslate_UnknownArrayElement() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
-                        new Attribute("fakeArray", Arrays.asList("top", "person", "organizationalPerson", "inetOrgPerson"))
-                }));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                new Attribute("fakeArray", Arrays.asList("top", "person", "organizationalPerson", "inetOrgPerson"))
+        });
 
         @SuppressWarnings("serial")
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
@@ -411,8 +379,7 @@ public class ResultTranslatorTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testTranslate_ObjectField() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{new Attribute("fake")}));
+        SearchResultEntry result =  new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{new Attribute("fake")});
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new ObjectField("fake")
@@ -423,8 +390,7 @@ public class ResultTranslatorTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testTranslate_ReferenceField() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{new Attribute("fake")}));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{new Attribute("fake")});
 
         EntityMetadata md = fakeEntityMetadata("fakeMetadata",
                 new ReferenceField("fake")
@@ -435,8 +401,7 @@ public class ResultTranslatorTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testTranslate_UnsupportedField() throws JSONException{
-        SearchResult result = fakeSearchResult(
-                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{new Attribute("fake")}));
+        SearchResultEntry result = new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{new Attribute("fake")});
 
         @SuppressWarnings("serial")
         EntityMetadata md = fakeEntityMetadata("fakeMetadata", new Field("fake"){
@@ -459,10 +424,6 @@ public class ResultTranslatorTest {
         });
 
         new ResultTranslator(factory).translate(result, md);
-    }
-
-    protected SearchResult fakeSearchResult(SearchResultEntry... entries){
-        return new SearchResult(-1, null, "", "", new String[0], Arrays.asList(entries), new ArrayList<SearchResultReference>(), entries.length, 0, null);
     }
 
     protected EntityMetadata fakeEntityMetadata(String name, Field... fields){

--- a/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslatorTest.java
+++ b/lightblue-ldap-crud/src/test/java/com/redhat/lightblue/crud/ldap/translator/ResultTranslatorTest.java
@@ -220,6 +220,20 @@ public class ResultTranslatorTest {
                 true);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testTranslate_SimpleField_NullValue() throws JSONException{
+        SearchResult result = fakeSearchResult(
+                new SearchResultEntry(-1, "uid=john.doe,dc=example,dc=com", new Attribute[]{
+                        new Attribute("uid")
+                }));
+
+        EntityMetadata md = fakeEntityMetadata("fakeMetadata",
+                new SimpleField("uid", StringType.TYPE)
+                );
+
+        new ResultTranslator(factory).translate(result, md);
+    }
+
     @Test
     public void testTranslate_SimpleField_BinaryType() throws Exception{
         byte[] bite = new byte[]{1, 2, 3, 'a', 'b', 'c'};

--- a/lightblue-ldap-crud/src/test/resources/crud/insert/entryBuilderTest-insert-template.json
+++ b/lightblue-ldap-crud/src/test/resources/crud/insert/entryBuilderTest-insert-template.json
@@ -1,0 +1,7 @@
+{
+    "entity": "entryBuilderTest",
+    "entityVersion": "1.0.0",
+    "data": {
+        "#fieldname": #value
+    }
+}

--- a/lightblue-ldap-crud/src/test/resources/metadata/entryBuilderTest-metadata-template.json
+++ b/lightblue-ldap-crud/src/test/resources/metadata/entryBuilderTest-metadata-template.json
@@ -1,0 +1,30 @@
+{
+    "entityInfo": {
+        "name": "entryBuilderTest",
+        "datastore": {
+            "backend":"ldap",
+            "database": "test",
+            "basedn": "dc=example,dc=com",
+            "uniqueattr": "uid"
+        }
+    },
+    "schema": {
+        "name": "entryBuilderTest",
+        "version": {
+            "value": "1.0.0",
+            "changelog": "blahblah"
+        },
+        "status": {
+            "value": "active"
+        },
+        "access" : {
+             "insert": ["anyone"],
+             "update": ["anyone"],
+             "delete": ["anyone"],
+             "find": ["anyone"]
+        },
+        "fields": {
+            "#fieldname": #type
+        }
+    }
+}

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractCRUDController.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractCRUDController.java
@@ -1,0 +1,58 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.crud.ldap;
+
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
+
+import org.junit.ClassRule;
+
+import com.redhat.lightblue.config.DataSourcesConfiguration;
+import com.redhat.lightblue.config.JsonTranslator;
+import com.redhat.lightblue.config.LightblueFactory;
+import com.redhat.lightblue.metadata.EntityMetadata;
+import com.redhat.lightblue.metadata.Metadata;
+import com.redhat.lightblue.mongo.test.MongoServerExternalResource;
+import com.redhat.lightblue.mongo.test.MongoServerExternalResource.InMemoryMongoServer;
+
+@InMemoryMongoServer
+public abstract class AbstractCRUDController {
+
+    @ClassRule
+    public static MongoServerExternalResource mongoServer = new MongoServerExternalResource();
+
+    protected static LightblueFactory lightblueFactory;
+
+    protected static void init(String datasourcesResourcePath, String... metadataResourcePaths)
+            throws Exception {
+        lightblueFactory = new LightblueFactory(
+                new DataSourcesConfiguration(loadJsonNode(datasourcesResourcePath)));
+
+        JsonTranslator tx = lightblueFactory.getJsonTranslator();
+
+        Metadata metadata = lightblueFactory.getMetadata();
+        for(String metadataResourcePath : metadataResourcePaths){
+            metadata.createNewMetadata(tx.parse(EntityMetadata.class, loadJsonNode(metadataResourcePath)));
+        }
+    }
+
+    protected static void cleanup(){
+        lightblueFactory = null;
+    }
+
+}

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractCRUDController.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractCRUDController.java
@@ -20,6 +20,7 @@ package com.redhat.lightblue.crud.ldap;
 
 import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
 
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 
 import com.redhat.lightblue.config.DataSourcesConfiguration;
@@ -38,7 +39,7 @@ public abstract class AbstractCRUDController {
 
     protected static LightblueFactory lightblueFactory;
 
-    protected static void init(String datasourcesResourcePath, String... metadataResourcePaths)
+    protected static void initLightblueFactory(String datasourcesResourcePath, String... metadataResourcePaths)
             throws Exception {
         lightblueFactory = new LightblueFactory(
                 new DataSourcesConfiguration(loadJsonNode(datasourcesResourcePath)));
@@ -51,7 +52,8 @@ public abstract class AbstractCRUDController {
         }
     }
 
-    protected static void cleanup(){
+    @AfterClass
+    public static void cleanup(){
         lightblueFactory = null;
     }
 

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractLdapCRUDController.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractLdapCRUDController.java
@@ -44,14 +44,6 @@ public abstract class AbstractLdapCRUDController extends AbstractCRUDController{
     @Rule
     public ErrorCollector errorCollector = new ErrorCollector();
 
-    protected static void initLdap(String datasourcesResourcePath, String... metadataResourcePaths) throws Exception{
-        init(datasourcesResourcePath, metadataResourcePaths);
-    }
-
-    protected static void cleanupLdap(){
-        cleanup();
-    }
-
     protected void assertNoErrors(Response response){
         for(Error error : response.getErrors()){
             Exception e = new Exception(error.getMessage(), error);

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractLdapCRUDController.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractLdapCRUDController.java
@@ -1,0 +1,84 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.crud.ldap;
+
+import static com.redhat.lightblue.util.JsonUtils.json;
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
+
+import java.io.IOException;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.DataError;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.config.JsonTranslator;
+import com.redhat.lightblue.ldap.test.LdapServerExternalResource;
+import com.redhat.lightblue.ldap.test.LdapServerExternalResource.InMemoryLdapServer;
+import com.redhat.lightblue.util.Error;
+
+@InMemoryLdapServer
+public abstract class AbstractLdapCRUDController extends AbstractCRUDController{
+
+    @ClassRule
+    public static LdapServerExternalResource ldapServer = LdapServerExternalResource.createDefaultInstance();
+
+    @Rule
+    public ErrorCollector errorCollector = new ErrorCollector();
+
+    protected static void initLdap(String datasourcesResourcePath, String... metadataResourcePaths) throws Exception{
+        init(datasourcesResourcePath, metadataResourcePaths);
+    }
+
+    protected static void cleanupLdap(){
+        cleanup();
+    }
+
+    protected void assertNoErrors(Response response){
+        for(Error error : response.getErrors()){
+            Exception e = new Exception(error.getMessage(), error);
+            e.printStackTrace();
+            errorCollector.addError(e);
+        }
+    }
+
+    protected void assertNoDataErrors(Response response){
+        for(DataError error : response.getDataErrors()){
+            Exception e = new Exception("DataError: " + error.toJson().toString());
+            e.printStackTrace();
+            errorCollector.addError(e);
+        }
+    }
+
+    protected <T> T createRequest_FromResource(Class<T> type, String jsonFile) throws IOException{
+        return createRequest(type, loadJsonNode(jsonFile));
+    }
+
+    protected <T> T createRequest_FromJsonString(Class<T> type, String jsonString) throws IOException{
+        return createRequest(type, json(jsonString));
+    }
+
+    protected <T> T createRequest(Class<T> type, JsonNode node) throws IOException{
+        JsonTranslator tx = lightblueFactory.getJsonTranslator();
+        return tx.parse(type, node);
+    }
+
+}

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDControllerTest.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDControllerTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNull;
 import java.util.Arrays;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -79,12 +78,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController{
         System.setProperty("mongo.port", String.valueOf(MongoServerExternalResource.DEFAULT_PORT));
         System.setProperty("mongo.database", "lightblue");
 
-        initLdap("./datasources.json", "./metadata/person-metadata.json", "./metadata/department-metadata.json");
-    }
-
-    @AfterClass
-    public static void afterClass(){
-        cleanupLdap();
+        initLightblueFactory("./datasources.json", "./metadata/person-metadata.json", "./metadata/department-metadata.json");
     }
 
     @Test

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDControllerTest.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDControllerTest.java
@@ -18,43 +18,30 @@
  */
 package com.redhat.lightblue.crud.ldap;
 
-import static com.redhat.lightblue.util.JsonUtils.json;
-import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
 import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ErrorCollector;
 import org.junit.runners.MethodSorters;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.redhat.lightblue.DataError;
 import com.redhat.lightblue.Response;
-import com.redhat.lightblue.config.DataSourcesConfiguration;
-import com.redhat.lightblue.config.JsonTranslator;
-import com.redhat.lightblue.config.LightblueFactory;
 import com.redhat.lightblue.crud.FindRequest;
 import com.redhat.lightblue.crud.InsertionRequest;
 import com.redhat.lightblue.ldap.test.LdapServerExternalResource;
 import com.redhat.lightblue.ldap.test.LdapServerExternalResource.InMemoryLdapServer;
-import com.redhat.lightblue.metadata.EntityMetadata;
-import com.redhat.lightblue.metadata.Metadata;
 import com.redhat.lightblue.mongo.test.MongoServerExternalResource;
 import com.redhat.lightblue.mongo.test.MongoServerExternalResource.InMemoryMongoServer;
 import com.redhat.lightblue.test.FakeClientIdentification;
-import com.redhat.lightblue.util.Error;
 import com.unboundid.ldap.sdk.Attribute;
 
 /**
@@ -66,21 +53,10 @@ import com.unboundid.ldap.sdk.Attribute;
 @InMemoryLdapServer
 @InMemoryMongoServer
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class ITCaseLdapCRUDControllerTest{
+public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController{
 
     private static final String BASEDB_USERS = "ou=Users,dc=example,dc=com";
     private static final String BASEDB_DEPARTMENTS = "ou=Departments,dc=example,dc=com";
-
-    @ClassRule
-    public static LdapServerExternalResource ldapServer = LdapServerExternalResource.createDefaultInstance();
-
-    @ClassRule
-    public static MongoServerExternalResource mongoServer = new MongoServerExternalResource();
-
-    @Rule
-    public ErrorCollector collector = new ErrorCollector();
-
-    public static LightblueFactory lightblueFactory;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -103,48 +79,12 @@ public class ITCaseLdapCRUDControllerTest{
         System.setProperty("mongo.port", String.valueOf(MongoServerExternalResource.DEFAULT_PORT));
         System.setProperty("mongo.database", "lightblue");
 
-        lightblueFactory = new LightblueFactory(
-                new DataSourcesConfiguration(loadJsonNode("./datasources.json")));
-
-        JsonTranslator tx = lightblueFactory.getJsonTranslator();
-
-        Metadata metadata = lightblueFactory.getMetadata();
-        metadata.createNewMetadata(tx.parse(EntityMetadata.class, loadJsonNode("./metadata/person-metadata.json")));
-        metadata.createNewMetadata(tx.parse(EntityMetadata.class, loadJsonNode("./metadata/department-metadata.json")));
+        initLdap("./datasources.json", "./metadata/person-metadata.json", "./metadata/department-metadata.json");
     }
 
     @AfterClass
-    public static void after(){
-        lightblueFactory = null;
-    }
-
-    private void assertNoErrors(Response response){
-        for(Error error : response.getErrors()){
-            Exception e = new Exception(error.getMessage(), error);
-            e.printStackTrace();
-            collector.addError(e);
-        }
-    }
-
-    private void assertNoDataErrors(Response response){
-        for(DataError error : response.getDataErrors()){
-            Exception e = new Exception("DataError: " + error.toJson().toString());
-            e.printStackTrace();
-            collector.addError(e);
-        }
-    }
-
-    private <T> T createRequest_FromResource(Class<T> type, String jsonFile) throws IOException{
-        return createRequest(type, loadJsonNode(jsonFile));
-    }
-
-    private <T> T createRequest_FromJsonString(Class<T> type, String jsonString) throws IOException{
-        return createRequest(type, json(jsonString));
-    }
-
-    private <T> T createRequest(Class<T> type, JsonNode node) throws IOException{
-        JsonTranslator tx = lightblueFactory.getJsonTranslator();
-        return tx.parse(type, node);
+    public static void afterClass(){
+        cleanupLdap();
     }
 
     @Test

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_DataType_Test.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_DataType_Test.java
@@ -28,7 +28,6 @@ import java.util.Date;
 
 import javax.xml.bind.DatatypeConverter;
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,12 +65,7 @@ public class ITCaseLdapCRUDController_DataType_Test extends AbstractLdapCRUDCont
         System.setProperty("mongo.port", String.valueOf(MongoServerExternalResource.DEFAULT_PORT));
         System.setProperty("mongo.database", "lightblue");
 
-        initLdap("./datasources.json", "./metadata/datatype-metadata.json");
-    }
-
-    @AfterClass
-    public static void afterClass(){
-        cleanupLdap();
+        initLightblueFactory("./datasources.json", "./metadata/datatype-metadata.json");
     }
 
     private final String cn;

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_DataType_Test.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_DataType_Test.java
@@ -1,0 +1,122 @@
+/*
+ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+
+ This file is part of lightblue.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.redhat.lightblue.crud.ldap;
+
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadResource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.Response;
+import com.redhat.lightblue.crud.FindRequest;
+import com.redhat.lightblue.crud.InsertionRequest;
+import com.redhat.lightblue.ldap.test.LdapServerExternalResource;
+import com.redhat.lightblue.metadata.types.DateType;
+import com.redhat.lightblue.mongo.test.MongoServerExternalResource;
+
+@RunWith(value = Parameterized.class)
+public class ITCaseLdapCRUDController_DataType_Test extends AbstractLdapCRUDController{
+
+    @Parameters(name= "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {"date", "testdate", DateType.getDateFormat().format(new Date())},
+                {"binary", "testbinary", DatatypeConverter.printBase64Binary("test binary data".getBytes())}
+        });
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception{
+        System.setProperty("ldap.host", "localhost");
+        System.setProperty("ldap.port", String.valueOf(LdapServerExternalResource.DEFAULT_PORT));
+        System.setProperty("ldap.database", "test");
+        System.setProperty("ldap.datatype.basedn", "dc=example,dc=com");
+
+        System.setProperty("mongo.host", "localhost");
+        System.setProperty("mongo.port", String.valueOf(MongoServerExternalResource.DEFAULT_PORT));
+        System.setProperty("mongo.database", "lightblue");
+
+        initLdap("./datasources.json", "./metadata/datatype-metadata.json");
+    }
+
+    @AfterClass
+    public static void afterClass(){
+        cleanupLdap();
+    }
+
+    private final String cn;
+    private final String fieldName;
+    private final String data;
+
+    public ITCaseLdapCRUDController_DataType_Test(String cn, String fieldName, String data){
+        this.cn = cn;
+        this.fieldName = fieldName;
+        this.data = data;
+    }
+
+    @Test
+    public void testInsertThenFindField() throws Exception{
+        String insert = loadResource("./crud/insert/datatype-insert-template.json")
+                .replaceFirst("#cn", cn)
+                .replaceFirst("#field", fieldName)
+                .replaceFirst("#fielddata", data);
+
+        Response insertResponse = lightblueFactory.getMediator().insert(
+                createRequest_FromJsonString(InsertionRequest.class, insert));
+
+        assertNotNull(insertResponse);
+        assertNoErrors(insertResponse);
+        assertNoDataErrors(insertResponse);
+        assertEquals(1, insertResponse.getModifiedCount());
+
+        String find = loadResource("./crud/find/datatype-find-template.json")
+                .replaceFirst("#cn", cn)
+                .replaceFirst("#field", fieldName);
+
+        Response findResponse = lightblueFactory.getMediator().find(
+                createRequest_FromJsonString(FindRequest.class, find));
+
+        assertNotNull(findResponse);
+        assertNoErrors(findResponse);
+        assertNoDataErrors(findResponse);
+        assertEquals(1, findResponse.getMatchCount());
+
+        JsonNode entityData = findResponse.getEntityData();
+        assertNotNull(entityData);
+
+        JSONAssert.assertEquals(
+                "[{\"" + fieldName + "\":\"" + data + "\"}]",
+                entityData.toString(), true);
+    }
+
+}

--- a/lightblue-ldap-integration-test/src/test/resources/crud/find/datatype-find-template.json
+++ b/lightblue-ldap-integration-test/src/test/resources/crud/find/datatype-find-template.json
@@ -1,0 +1,12 @@
+{
+    "entity": "datatype",
+    "entityVersion": "1.0.0",
+    "projection": [
+        {"field": "#field"}
+    ],
+    "query": {
+        "field": "cn",
+        "op": "$eq",
+        "rvalue": "#cn"
+    }
+}

--- a/lightblue-ldap-integration-test/src/test/resources/crud/insert/datatype-insert-template.json
+++ b/lightblue-ldap-integration-test/src/test/resources/crud/insert/datatype-insert-template.json
@@ -1,0 +1,12 @@
+{
+    "entity": "datatype",
+    "entityVersion": "1.0.0",
+    "projection": {
+        "field": "dn"
+    },
+    "data": {
+        "objectClass": ["top"],
+        "cn": "#cn",
+        "#field": "#fielddata"
+    }
+}

--- a/lightblue-ldap-integration-test/src/test/resources/crud/insert/department-insert-template.json
+++ b/lightblue-ldap-integration-test/src/test/resources/crud/insert/department-insert-template.json
@@ -5,7 +5,7 @@
         "field": "dn"
     },
     "data": {
-        "objectClass": ["groupofNames"],
+        "objectClass": ["top", "groupofNames"],
         "cn": "#cn",
         "description": "#description",
         "member": [#members]

--- a/lightblue-ldap-integration-test/src/test/resources/metadata/datatype-metadata.json
+++ b/lightblue-ldap-integration-test/src/test/resources/metadata/datatype-metadata.json
@@ -1,0 +1,32 @@
+{
+    "entityInfo": {
+        "name": "datatype",
+        "datastore": {
+            "backend":"ldap",
+            "database": "${ldap.database}",
+            "basedn": "${ldap.datatype.basedn}",
+            "uniqueattr": "cn"
+        }
+    },
+    "schema": {
+        "name": "datatype",
+        "version": {
+            "value": "1.0.0",
+            "changelog": "blahblah"
+        },
+        "status": {
+            "value": "active"
+        },
+        "access": {
+             "insert": ["anyone"],
+             "update": ["anyone"],
+             "delete": ["anyone"],
+             "find": ["anyone"]
+        },
+        "fields": {
+            "cn": {"type": "string"},
+            "testdate": {"type": "date"},
+            "testbinary": {"type": "binary"}
+        }
+    }
+}


### PR DESCRIPTION
There are some big changes in this PR.

Highlights:
* entitymetadata is now being used to translate json to an ldap Entry.
* Created generic TranslatorFromJson with the hope that it possibly be moved to core and reused
* Created EntryBuilder as an implementation of TranslatorFromJson for Ldap
* Created integration tests to ensure date and binary types work properly
* Abstracted some of the CRUDController test code which could possibly be promoted to core.test and reused