### PR TITLE
fix crud errors so that they actually are sent to the client

### DIFF
--- a/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/LdapCRUDController.java
+++ b/lightblue-ldap-crud/src/main/java/com/redhat/lightblue/crud/ldap/LdapCRUDController.java
@@ -235,9 +235,7 @@ public class LdapCRUDController implements CRUDController{
                     translatedDocs.add(resultTranslator.translate(entry));
                 }
                 catch(Exception e){
-                    DocCtx erroredDoc = new DocCtx(null);
-                    erroredDoc.addError(Error.get(e));
-                    translatedDocs.add(erroredDoc);
+                    ctx.addError(Error.get(e));
                 }
             }
             ctx.setDocuments(translatedDocs);

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractLdapCRUDController.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/AbstractLdapCRUDController.java
@@ -22,10 +22,11 @@ import static com.redhat.lightblue.util.JsonUtils.json;
 import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.ErrorCollector;
+import org.junit.runners.model.MultipleFailureException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.lightblue.DataError;
@@ -41,22 +42,29 @@ public abstract class AbstractLdapCRUDController extends AbstractCRUDController{
     @ClassRule
     public static LdapServerExternalResource ldapServer = LdapServerExternalResource.createDefaultInstance();
 
-    @Rule
-    public ErrorCollector errorCollector = new ErrorCollector();
-
-    protected void assertNoErrors(Response response){
+    protected void assertNoErrors(Response response) throws MultipleFailureException{
+        List<Throwable> errors = new ArrayList<Throwable>();
         for(Error error : response.getErrors()){
             Exception e = new Exception(error.getMessage(), error);
             e.printStackTrace();
-            errorCollector.addError(e);
+            errors.add(e);
+        }
+
+        if(!errors.isEmpty()){
+            throw new MultipleFailureException(errors);
         }
     }
 
-    protected void assertNoDataErrors(Response response){
+    protected void assertNoDataErrors(Response response) throws MultipleFailureException{
+        List<Throwable> errors = new ArrayList<Throwable>();
         for(DataError error : response.getDataErrors()){
             Exception e = new Exception("DataError: " + error.toJson().toString());
             e.printStackTrace();
-            errorCollector.addError(e);
+            errors.add(e);
+        }
+
+        if(!errors.isEmpty()){
+            throw new MultipleFailureException(errors);
         }
     }
 


### PR DESCRIPTION
I noticed while debugging another issue that errors were not actually being received by client applications. This change fixes that. 