### PR TITLE
Updated tests to use getLightblueFactory()

### DIFF
--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDControllerTest.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDControllerTest.java
@@ -43,6 +43,7 @@ import com.redhat.lightblue.ldap.test.LdapServerExternalResource;
 import com.redhat.lightblue.mongo.test.MongoServerExternalResource;
 import com.redhat.lightblue.test.FakeClientIdentification;
 import com.unboundid.ldap.sdk.Attribute;
+import java.io.IOException;
 
 /**
  * <b>NOTE:</b> This test suite is intended to be run in a certain order. Selectively running unit tests
@@ -83,7 +84,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
     }
 
     @Override
-    protected JsonNode[] getMetadataJsonNodes() throws Exception {
+    protected JsonNode[] getMetadataJsonNodes() throws IOException {
         return new JsonNode[]{
                 loadJsonNode("./metadata/person-metadata.json"),
                 loadJsonNode("./metadata/department-metadata.json")};
@@ -91,7 +92,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
 
     @Test
     public void series1_phase1_Person_Insert() throws Exception {
-        Response response = lightblueFactory.getMediator().insert(
+        Response response = getLightblueFactory().getMediator().insert(
                 createRequest_FromResource(InsertionRequest.class, "./crud/insert/person-insert-many.json"));
 
         assertNotNull(response);
@@ -108,7 +109,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
 
     @Test
     public void series1_phase2_Person_FindSingle() throws Exception {
-        Response response = lightblueFactory.getMediator().find(
+        Response response = getLightblueFactory().getMediator().find(
                 createRequest_FromResource(FindRequest.class, "./crud/find/person-find-single.json"));
 
         assertNotNull(response);
@@ -125,7 +126,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
 
     @Test
     public void series1_phase2_Person_FindMany() throws Exception {
-        Response response = lightblueFactory.getMediator().find(
+        Response response = getLightblueFactory().getMediator().find(
                 createRequest_FromResource(FindRequest.class, "./crud/find/person-find-many.json"));
 
         assertNotNull(response);
@@ -144,7 +145,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
 
     @Test
     public void series1_phase2_Person_FindMany_WithPagination() throws Exception {
-        Response response = lightblueFactory.getMediator().find(
+        Response response = getLightblueFactory().getMediator().find(
                 createRequest_FromResource(FindRequest.class, "./crud/find/person-find-many-paginated.json"));
 
         assertNotNull(response);
@@ -170,7 +171,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
         InsertionRequest insertRequest = createRequest_FromJsonString(InsertionRequest.class, insert);
         insertRequest.setClientId(new FakeClientIdentification("fakeUser", "admin"));
 
-        Response response = lightblueFactory.getMediator().insert(insertRequest);
+        Response response = getLightblueFactory().getMediator().insert(insertRequest);
 
         assertNotNull(response);
         assertNoErrors(response);
@@ -194,7 +195,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
         InsertionRequest insertRequest = createRequest_FromJsonString(InsertionRequest.class, insert);
         insertRequest.setClientId(new FakeClientIdentification("fakeUser"));
 
-        Response response = lightblueFactory.getMediator().insert(insertRequest);
+        Response response = getLightblueFactory().getMediator().insert(insertRequest);
 
         assertNotNull(response);
         assertEquals(0, response.getModifiedCount());
@@ -212,7 +213,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
         FindRequest findRequest = createRequest_FromResource(FindRequest.class, "./crud/find/department-find-single.json");
         findRequest.setClientId(new FakeClientIdentification("fakeUser", "admin"));
 
-        Response response = lightblueFactory.getMediator().find(findRequest);
+        Response response = getLightblueFactory().getMediator().find(findRequest);
 
         assertNotNull(response);
         assertNoErrors(response);
@@ -231,7 +232,7 @@ public class ITCaseLdapCRUDControllerTest extends AbstractLdapCRUDController {
         FindRequest findRequest = createRequest_FromResource(FindRequest.class, "./crud/find/department-find-single.json");
         findRequest.setClientId(new FakeClientIdentification("fakeUser"));
 
-        Response response = lightblueFactory.getMediator().find(findRequest);
+        Response response = getLightblueFactory().getMediator().find(findRequest);
 
         assertNotNull(response);
         assertEquals(1, response.getMatchCount());

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_DataType_Test.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_DataType_Test.java
@@ -25,7 +25,6 @@ import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -93,7 +92,7 @@ public class ITCaseLdapCRUDController_DataType_Test extends AbstractLdapCRUDCont
                 .replaceFirst("#field", fieldName)
                 .replaceFirst("#fielddata", data);
 
-        Response insertResponse = lightblueFactory.getMediator().insert(
+        Response insertResponse = getLightblueFactory().getMediator().insert(
                 createRequest_FromJsonString(InsertionRequest.class, insert));
 
         assertNotNull(insertResponse);
@@ -105,7 +104,7 @@ public class ITCaseLdapCRUDController_DataType_Test extends AbstractLdapCRUDCont
                 .replaceFirst("#cn", cn)
                 .replaceFirst("#field", fieldName);
 
-        Response findResponse = lightblueFactory.getMediator().find(
+        Response findResponse = getLightblueFactory().getMediator().find(
                 createRequest_FromJsonString(FindRequest.class, find));
 
         assertNotNull(findResponse);

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_InvalidMetadata_Test.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_InvalidMetadata_Test.java
@@ -75,8 +75,8 @@ public class ITCaseLdapCRUDController_InvalidMetadata_Test extends AbstractLdapC
         String metadataWithoutUniqueField = loadResource("./metadata/person-metadata.json").replaceFirst("\"uid\": \\{\"type\": \"string\"\\},", "");
         JsonNode nodeWithoutUniqueField = json(metadataWithoutUniqueField);
 
-        Metadata metadata = lightblueFactory.getMetadata();
-        metadata.createNewMetadata(lightblueFactory.getJsonTranslator().parse(EntityMetadata.class, nodeWithoutUniqueField));
+        Metadata metadata = getLightblueFactory().getMetadata();
+        metadata.createNewMetadata(getLightblueFactory().getJsonTranslator().parse(EntityMetadata.class, nodeWithoutUniqueField));
     }
 
 }

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_Objects_Test.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_Objects_Test.java
@@ -71,7 +71,7 @@ public class ITCaseLdapCRUDController_Objects_Test extends AbstractLdapCRUDContr
 
     @Test
     public void test1PersonWithAddress_Insert() throws Exception {
-        Response response = lightblueFactory.getMediator().insert(
+        Response response = getLightblueFactory().getMediator().insert(
                 createRequest_FromResource(InsertionRequest.class, "./crud/insert/person-with-address-insert-single.json"));
 
         assertNotNull(response);
@@ -88,7 +88,7 @@ public class ITCaseLdapCRUDController_Objects_Test extends AbstractLdapCRUDContr
 
     @Test
     public void test2PersonWithAddress_Find() throws Exception {
-        Response response = lightblueFactory.getMediator().find(
+        Response response = getLightblueFactory().getMediator().find(
                 createRequest_FromResource(FindRequest.class, "./crud/find/person-with-address-find-single.json"));
 
         assertNotNull(response);

--- a/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_WithProperties_Test.java
+++ b/lightblue-ldap-integration-test/src/test/java/com/redhat/lightblue/crud/ldap/ITCaseLdapCRUDController_WithProperties_Test.java
@@ -76,7 +76,7 @@ public class ITCaseLdapCRUDController_WithProperties_Test extends AbstractLdapCR
 
     @Test
     public void test1CustomerInsertWithProperties() throws Exception {
-        Response response = lightblueFactory.getMediator().insert(
+        Response response = getLightblueFactory().getMediator().insert(
                 createRequest_FromResource(InsertionRequest.class, "./crud/insert/customer-insert-single.json"));
 
         assertNotNull(response);
@@ -93,7 +93,7 @@ public class ITCaseLdapCRUDController_WithProperties_Test extends AbstractLdapCR
 
     @Test
     public void test2FindCustomerWithProperties() throws Exception {
-        Response response = lightblueFactory.getMediator().find(
+        Response response = getLightblueFactory().getMediator().find(
                 createRequest_FromResource(FindRequest.class, "./crud/find/customer-find-single.json"));
 
         assertNotNull(response);

--- a/lightblue-ldap-integration-test/src/test/resources/crud/insert/department-insert-template.json
+++ b/lightblue-ldap-integration-test/src/test/resources/crud/insert/department-insert-template.json
@@ -8,6 +8,6 @@
         "objectClass": ["top", "groupofNames"],
         "cn": "#cn",
         "description": "#description",
-        "member": ["#members"]
+        "member": [#members]
     }
 }

--- a/lightblue-ldap-integration-test/src/test/resources/crud/insert/department-insert-template.json
+++ b/lightblue-ldap-integration-test/src/test/resources/crud/insert/department-insert-template.json
@@ -8,6 +8,6 @@
         "objectClass": ["top", "groupofNames"],
         "cn": "#cn",
         "description": "#description",
-        "member": [#members]
+        "member": ["#members"]
     }
 }


### PR DESCRIPTION
Depends on https://github.com/lightblue-platform/lightblue-core/pull/355 being merged.

Local builds are failing but not because of anything I changed.

@dcrissman if this still fails here, might need your eyes on it.  It's complaining when trying to create metadata from test resource `metadata/datatype-metadata.json`.