### PR TITLE
create lightblue-ldap rpm

### DIFF
--- a/lightblue-ldap-config/pom.xml
+++ b/lightblue-ldap-config/pom.xml
@@ -73,7 +73,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <name>${project.artifactId}</name>
+                    <name>${rpm.name}</name>
                     <copyright>Red Hat</copyright>
                     <distribution>RHEL</distribution>
                     <group>Lightblue Platform</group>
@@ -87,7 +87,7 @@
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
-                                    <location>target/lightblue-ldap-${project.version}.${project.packaging}</location>
+                                    <location>target/${project.artifactId}-${project.version}.${project.packaging}</location>
                                 </source>
                             </sources>
                             <dependency>

--- a/lightblue-ldap-config/pom.xml
+++ b/lightblue-ldap-config/pom.xml
@@ -57,4 +57,50 @@
        </dependency>
     </dependencies>
     
+    <build>
+        <plugins>
+            <!-- RPM packing -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>rpm-maven-plugin</artifactId>
+                <version>2.1.4</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>attached-rpm</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <name>${project.artifactId}</name>
+                    <copyright>Red Hat</copyright>
+                    <distribution>RHEL</distribution>
+                    <group>Lightblue Platform</group>
+                    <packager>${user.name}</packager>
+                    <defaultFilemode>744</defaultFilemode>
+                    <defaultUsername>jboss</defaultUsername>
+                    <defaultGroupname>jboss</defaultGroupname>
+                    <mappings>
+                        <mapping>
+                            <directory>${rpm.install.basedir}</directory>
+                            <directoryIncluded>false</directoryIncluded>
+                            <sources>
+                                <source>
+                                    <location>target/lightblue-ldap-${project.version}.${project.packaging}</location>
+                                </source>
+                            </sources>
+                            <dependency>
+                              <includes>
+                                <include>com.redhat.lightblue.ldap:*</include>
+                                <include>com.unboundid:unboundid-ldapsdk</include>
+                              </includes>
+                            </dependency>
+                        </mapping>
+                    </mappings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
 </project>

--- a/lightblue-ldap-config/pom.xml
+++ b/lightblue-ldap-config/pom.xml
@@ -57,50 +57,55 @@
        </dependency>
     </dependencies>
     
-    <build>
-        <plugins>
-            <!-- RPM packing -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>rpm-maven-plugin</artifactId>
-                <version>2.1.4</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>attached-rpm</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <name>${rpm.name}</name>
-                    <copyright>Red Hat</copyright>
-                    <distribution>RHEL</distribution>
-                    <group>Lightblue Platform</group>
-                    <packager>${user.name}</packager>
-                    <defaultFilemode>744</defaultFilemode>
-                    <defaultUsername>jboss</defaultUsername>
-                    <defaultGroupname>jboss</defaultGroupname>
-                    <mappings>
-                        <mapping>
-                            <directory>${rpm.install.basedir}</directory>
-                            <directoryIncluded>false</directoryIncluded>
-                            <sources>
-                                <source>
-                                    <location>target/${project.artifactId}-${project.version}.${project.packaging}</location>
-                                </source>
-                            </sources>
-                            <dependency>
-                              <includes>
-                                <include>com.redhat.lightblue.ldap:*</include>
-                                <include>com.unboundid:unboundid-ldapsdk</include>
-                              </includes>
-                            </dependency>
-                        </mapping>
-                    </mappings>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+      <profile>
+        <id>rpm</id>
+        <build>
+            <plugins>
+                <!-- RPM packing -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>rpm-maven-plugin</artifactId>
+                    <version>2.1.4</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>attached-rpm</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <name>${rpm.name}</name>
+                        <copyright>Red Hat</copyright>
+                        <distribution>RHEL</distribution>
+                        <group>Lightblue Platform</group>
+                        <packager>${user.name}</packager>
+                        <defaultFilemode>744</defaultFilemode>
+                        <defaultUsername>jboss</defaultUsername>
+                        <defaultGroupname>jboss</defaultGroupname>
+                        <mappings>
+                            <mapping>
+                                <directory>${rpm.install.basedir}</directory>
+                                <directoryIncluded>false</directoryIncluded>
+                                <sources>
+                                    <source>
+                                        <location>target/${project.artifactId}-${project.version}.${project.packaging}</location>
+                                    </source>
+                                </sources>
+                                <dependency>
+                                  <includes>
+                                    <include>com.redhat.lightblue.ldap:*</include>
+                                    <include>com.unboundid:unboundid-ldapsdk</include>
+                                  </includes>
+                                </dependency>
+                            </mapping>
+                        </mappings>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+      </profile>
+    </profiles>
     
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,8 @@
         <sonar.jdbc.password>sonar</sonar.jdbc.password>
         <sonar.host.url>http://127.0.0.1:8080</sonar.host.url>
         <sonar.projectName>lightblue-ldap</sonar.projectName>
+        
+        <rpm.install.basedir>/usr/share/java/lightblue/lightblue-ldap</rpm.install.basedir>
 
         <lightblue.core.version>1.11.0-SNAPSHOT</lightblue.core.version>
         <lightblue.mongo.version>1.11.0-SNAPSHOT</lightblue.mongo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <sonar.host.url>http://127.0.0.1:8080</sonar.host.url>
         <sonar.projectName>lightblue-ldap</sonar.projectName>
         
+        <rpm.name>lightblue-ldap</rpm.name>
         <rpm.install.basedir>/usr/share/java/lightblue/lightblue-ldap</rpm.install.basedir>
 
         <lightblue.core.version>1.11.0-SNAPSHOT</lightblue.core.version>


### PR DESCRIPTION
Associated with https://github.com/lightblue-platform/lightblue-rest/issues/162

This new rpm will allow lightblue-ldap to be deployed as a true plugin to lightblue, and not need to be included in lightblue-rest as it is today.